### PR TITLE
Disable proxy_buffering for API requests

### DIFF
--- a/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
+++ b/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
@@ -88,6 +88,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_buffering         off;
         }
  
         location @direct-fallback {


### PR DESCRIPTION
This prevents nginx from buffering calls to `_changes` (which are processed through `medic-api`).

Fix for medic/medic-webapp#2363
