### PR TITLE
reconfigured nginx to redirect all non-ssl requests.

### DIFF
--- a/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
+++ b/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
@@ -30,8 +30,17 @@ http {
 
     server {
         listen       80;
+        server_name   _;
+        error_log /srv/storage/medic-core/nginx/logs/error.log;
+        location / {
+            return       301 https://$host$request_uri;
+        }
+    }
+
+    server {
         listen       443 ssl;
-        server_name  localhost;
+        server_name  _;
+        error_log /srv/storage/medic-core/nginx/logs/error-ssl.log;
 
         gzip                on;
         gzip_disable        "msie6";
@@ -69,6 +78,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
 
         location @app-redirect {
@@ -96,6 +106,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
 
         location / {
@@ -104,6 +115,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
 
         location @fallback {
@@ -111,6 +123,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
  
         location @direct-fallback {
@@ -118,6 +131,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
 
         location /dashboard {
@@ -126,6 +140,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
  
         location /_users {
@@ -134,6 +149,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
  
         location /_log {
@@ -142,6 +158,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
  
         location /_replicate {
@@ -150,6 +167,7 @@ http {
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto https;
         }
 
         error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
Not sure what is the best way to handle ssl-only mode, but starting a branch so at least these settings don't get lost and it stays on the radar.
