### PR TITLE
Restrict futon

### DIFF
--- a/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
+++ b/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
@@ -84,27 +84,8 @@ http {
             return 302 /medic/_design/medic/_rewrite;
         }
 
-        location = /_utils {
-            return 301 /_couch/_utils/index.html;
-        }
-
         location ~ ^/_utils/(.*) {
-            return 301 /_couch/_utils/$1;
-        }
-
-        location = /_couch/_utils {
-            return 301 /_couch/_utils/index.html;
-        }
-
-        location = /_couch/_utils/ {
-            return 301 /_couch/_utils/index.html;
-        }
-
-        location /_couch {
-            proxy_pass              http://medic-api/dashboard/_design/dashboard/_rewrite/_couch;
-            proxy_set_header        Host            $host;
-            proxy_set_header        X-Real-IP       $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            deny all;
         }
 
         location / {
@@ -121,17 +102,10 @@ http {
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
         }
- 
-        location @direct-fallback {
-            proxy_pass              http://couchdb;
-            proxy_set_header        Host            $host;
-            proxy_set_header        X-Real-IP       $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
 
         location /dashboard {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -139,7 +113,7 @@ http {
  
         location /_users {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -147,7 +121,7 @@ http {
  
         location /_log {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -155,7 +129,7 @@ http {
  
         location /_replicate {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Restrict futon based on medic/medic-webapp/issues/3360.  @browndav I had to include a `deny all;` for the `location ~ ^/_utils/(.*)` in order to get it blocked from outside the instance.