### PR TITLE
Restrict futon

### DIFF
--- a/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
+++ b/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
@@ -85,28 +85,8 @@ http {
             return 302 /medic/_design/medic/_rewrite;
         }
 
-        location = /_utils {
-            return 301 /_couch/_utils/index.html;
-        }
-
         location ~ ^/_utils/(.*) {
-            return 301 /_couch/_utils/$1;
-        }
-
-        location = /_couch/_utils {
-            return 301 /_couch/_utils/index.html;
-        }
-
-        location = /_couch/_utils/ {
-            return 301 /_couch/_utils/index.html;
-        }
-
-        location /_couch {
-            proxy_pass              http://medic-api/dashboard/_design/dashboard/_rewrite/_couch;
-            proxy_set_header        Host            $host;
-            proxy_set_header        X-Real-IP       $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header        X-Forwarded-Proto https;
+            deny all;
         }
 
         location / {
@@ -125,18 +105,10 @@ http {
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header        X-Forwarded-Proto https;
         }
- 
-        location @direct-fallback {
-            proxy_pass              http://couchdb;
-            proxy_set_header        Host            $host;
-            proxy_set_header        X-Real-IP       $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header        X-Forwarded-Proto https;
-        }
 
         location /dashboard {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -145,7 +117,7 @@ http {
  
         location /_users {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -154,7 +126,7 @@ http {
  
         location /_log {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -163,7 +135,7 @@ http {
  
         location /_replicate {
             proxy_pass              http://concierge;
-            error_page              502 503 504 = @direct-fallback;
+            error_page              502 503 504 = @fallback;
             proxy_set_header        Host            $host;
             proxy_set_header        X-Real-IP       $remote_addr;
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Restrict futon based on medic/medic-webapp#3360. @browndav I had to include a deny all; for the location ~ ^/_utils/(.*) in order to get it blocked from outside the instance.