### PR TITLE
Local Docker (HTTPS/SSL - Nginx) fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ QMAKE := ${MAKE} --no-print-directory
 
 # Public targets
 
-all: require-root download build docker
-repackage: do-repackage docker
+all: require-root download build
+repackage: do-repackage
 
 bootinit:
 	@cd platform && ${QMAKE} bootinit

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,10 @@ download: require-root prepare-tree
 	  ${QMAKE} force-move-downloaded; \
 	fi
 
-docker:
-	@docker-compose build
+# Legacy command. We now prepare-tree inside ubuntu container and not in a VM.
+# After files are modified on local filesystem, then run docker build from OSX
+#docker:
+#	@docker-compose build
 
 # Private targets
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ version: '2'
 services:
   medic-os:
     build: .
-    image: medic/medic-os:3.0.0-pre.07
+    image: medic/medic-os:3.0.0-pre.08

--- a/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
+++ b/platform/packages/medic-core/settings/medic-core/nginx/nginx.conf
@@ -86,10 +86,6 @@ http {
             root html;
         }
 
-        location / {
-            return 301 https://$host/medic/_design/medic/_rewrite/;
-        }
-
     }
 }
 

--- a/ubuntu_build_container.yml
+++ b/ubuntu_build_container.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  build_container:
+    image: ubuntu:16.04
+    volumes:
+      - .:/medic-os
+    working_dir: /medic-os
+    entrypoint:
+      - tail
+      - -f
+      - /dev/null


### PR DESCRIPTION
### Background
In our Staging/Production environment we terminate SSL at the Application Load Balancers, and force our main page to redirect to HTTPS.

### Solution
This breaks local setup as there is no ALB available. 
This PR adds an nginx conf with a self-signed certificate to get around the issue for local-use.

### Notes
Also adds a docker ubuntu container to utilize for build process instead of a VM.
And removes the docker-in-docker commands during the Make process.