### PR TITLE
pass ulimit all the way to couchdb proc

### DIFF
--- a/platform/packages/medic-core/scripts/medic-core/run/couchdb
+++ b/platform/packages/medic-core/scripts/medic-core/run/couchdb
@@ -12,7 +12,7 @@ start()
   local command_line="`which couchdb`" &&
   \
   exec /boot/timestamp \
-    su -c "exec $command_line" couchdb \
+    su -c "ulimit -n 100000 && exec $command_line" couchdb \
       >> "$PACKAGE_STORAGE/couchdb/logs/startup.log" 2>&1
 }
 

--- a/platform/packages/medic-core/settings/medic-core/couchdb/default.ini
+++ b/platform/packages/medic-core/settings/medic-core/couchdb/default.ini
@@ -55,7 +55,7 @@ changes_doc_ids_optimization_threshold = 100
 
 [cluster]
 q=8
-n=3
+n=1
 ; placement = metro-dc-a:2,metro-dc-b:1
 
 [chttpd]


### PR DESCRIPTION
In conjunction with [medic-infrastructure fix](https://github.com/medic/medic-infrastructure/pull/36)

These two solve the `max_open_files` issue with couchdb on rebuilding views a large data (lg-uganda) dataset in our v3 infrastructure.

