### PR TITLE
Horti hardcoded to install specific medic-api version

### DIFF
--- a/platform/packages/horticulturalist/scripts/horticulturalist/postrun/horticulturalist
+++ b/platform/packages/horticulturalist/scripts/horticulturalist/postrun/horticulturalist
@@ -31,7 +31,7 @@ bootstrap()
   \
   info 'Horticulturalist is now bootstrapping' &&
   \
-  export COUCH_NODE_NAME='couchdb@localhost' &&
+  export COUCH_NODE_NAME='couchdb@127.0.0.1' &&
   export COUCH_URL="http://${PACKAGE_NAME}:${passwd}@localhost:5984/medic" &&
   \
   local script="src/index.js" &&

--- a/platform/packages/horticulturalist/scripts/horticulturalist/postrun/horticulturalist
+++ b/platform/packages/horticulturalist/scripts/horticulturalist/postrun/horticulturalist
@@ -35,7 +35,7 @@ bootstrap()
   export COUCH_URL="http://${PACKAGE_NAME}:${passwd}@localhost:5984/medic" &&
   \
   local script="src/index.js" &&
-  local run_cmd="'`which node`' '$script' --medic-os --install --no-daemon" &&
+  local run_cmd="'`which node`' '$script' --medic-os --install=3.0.0 --no-daemon" &&
   \
   if [ "$DOCKER_HORTI_BOOTSTRAP" ]; then
     run_cmd="$run_cmd='$DOCKER_HORTI_BOOTSTRAP'"

--- a/platform/packages/horticulturalist/scripts/horticulturalist/run/horticulturalist
+++ b/platform/packages/horticulturalist/scripts/horticulturalist/run/horticulturalist
@@ -40,7 +40,7 @@ start()
   export COUCH_URL="http://${PACKAGE_NAME}:${password}@localhost:5984/medic" &&
   \
   local script="src/index.js" &&
-  local run_cmd="'`which node`' '$script' --medic-os" &&
+  local run_cmd="'`which node`' '$script' --medic-os --install=3.0.0" &&
   local command_line="cd '$PACKAGE_SOFTWARE' && exec $run_cmd" &&
   \
   chown_packages 'medic-api' 'medic-sentinel' &&

--- a/platform/packages/horticulturalist/scripts/horticulturalist/run/horticulturalist
+++ b/platform/packages/horticulturalist/scripts/horticulturalist/run/horticulturalist
@@ -36,7 +36,7 @@ start()
   export NODE_OPTIONS='--max_old_space_size=8192' &&
   \
   export HOME="$PACKAGE_STORAGE" &&
-  export COUCH_NODE_NAME='couchdb@localhost' &&
+  export COUCH_NODE_NAME='couchdb@127.0.0.1' &&
   export COUCH_URL="http://${PACKAGE_NAME}:${password}@localhost:5984/medic" &&
   \
   local script="src/index.js" &&


### PR DESCRIPTION
During medic-os startup scripts, horti was setup to pull `medic:medic:master` and install that version of medic-api.

It looks like `medic:medic:master` is the latest master branch and contains some breaking code. Horticulturalist hardcoded to install medic-api version 3.0.0 works as intended.

I'm okay with keeping this hardcoded to 3.0.0 on container launch since that is the base version of our new app + infrastructure. 