### PR TITLE
Make logrotate compress logs on rotate

### DIFF
--- a/platform/packages/medic-core/settings/medic-core/logrotate/logrotate.conf
+++ b/platform/packages/medic-core/settings/medic-core/logrotate/logrotate.conf
@@ -8,9 +8,9 @@ daily
 compress  
 rotate 21  
 copytruncate  
-compressext .bz2  
+compressext .gz 
 compressoptions -9  
 compresscmd /bin/gzip
-                                      
+
 include /etc/logrotate.d
 

--- a/platform/packages/medic-core/settings/medic-core/logrotate/logrotate.conf
+++ b/platform/packages/medic-core/settings/medic-core/logrotate/logrotate.conf
@@ -10,8 +10,7 @@ rotate 21
 copytruncate  
 compressext .bz2  
 compressoptions -9  
-compresscmd /usr/bin/bzip2  
-uncompresscmd /usr/bin/bunzip2  
+compresscmd /bin/gzip
                                       
 include /etc/logrotate.d
 


### PR DESCRIPTION
Logrotate was silently failing to zip logs on rotate with the error bellow. This fix changes the rotate cmd 
`compressing log with: /usr/bin/bzip2
error: failed to compress log `